### PR TITLE
Add user option to merge singnet -> opencog

### DIFF
--- a/merge-opencog-to-singnet.py
+++ b/merge-opencog-to-singnet.py
@@ -120,7 +120,7 @@ def fetch_repos(forks, sn_to_oc=False):
         src_repo, dst_repo = src_dst_repo(singnet_repo, opencog_repo, sn_to_oc)
         print(dst_repo["name"], end=": ")
         folder = dst_repo["name"]
-        run(["git", "fetch", "-all"], cwd=folder)
+        run(["git", "fetch", "--all"], cwd=folder)
         print("fetched")
 
 def remove_old_merge_branches(forks, sn_to_oc=False):

--- a/merge-opencog-to-singnet.py
+++ b/merge-opencog-to-singnet.py
@@ -338,7 +338,7 @@ if args.action == "merge":
     fetch_repos(forks, args.singnet_to_opencog)
     merge_opencog_to_singnet(forks, args.singnet_to_opencog)
     push_results(forks, args.singnet_to_opencog)
-    run_ci(forks, mrg_bch, singnet_to_opencog=args.singnet_to_opencog)
+    run_ci(forks, mrg_bch, sn_to_oc=args.singnet_to_opencog)
 elif args.action == "release":
     tag = args.tag
     if tag is None:
@@ -357,7 +357,7 @@ elif args.action == "fetch":
 elif args.action == "ci":
     forks = get_forks(api)
     run_ci(forks, args.ci_branch, user=args.ci_fork,
-           singnet_to_opencog=args.singnet_to_opencog)
+           sn_to_oc=args.singnet_to_opencog)
 elif args.action == "pr":
     forks = get_forks(api)
     raise_prs(api, user, forks, args.singnet_to_opencog)


### PR DESCRIPTION
Fix #6 

Some remarks, the `--singnet-to-opencog` overwrites the constant `MERGE_BRANCH` which is a bit ugly. Also I was forced to add the `singnet_to_opencog` bool argument to almost every function due to some repos having different names on opencog and singnet, such as `docker` vs `opencog-docker`. I think the code is complete with the exception of `tag_origin_master` because I wasn't sure I want to tag singnet every time I merge to opencog, so for now it is only run when merging from opencog to singnet. One last remark, if it's easier (for publish_dockers), know that the `singularitynet` dockerhub account is now mirrored by `singnet` dockerhub account.
